### PR TITLE
Many clicks on the same page result in a bug in jQuery fadeIn / fadeOut

### DIFF
--- a/jquery.blueberry.js
+++ b/jquery.blueberry.js
@@ -76,6 +76,13 @@
 				//rotate to selected slide on pager click
 				if(pager){
 					$('a', pager).click(function() {
+						
+						// stop transition when user click at the same page
+						var idx = $('.pager li a').index(this);
+						if (idx == current) {
+							return false;
+						}
+						
 						//stop the timer
 						clearTimeout(obj.play);
 						//set the slide index based on pager index


### PR DESCRIPTION
The solution for this case was to check if the user is clicking on the same page and prevent from performing the rotate action.
