### PR TITLE
Fix sync when user click repeatedly on pager nav

### DIFF
--- a/jquery.blueberry.js
+++ b/jquery.blueberry.js
@@ -112,6 +112,7 @@
 				};
 				//create a timer to control slide rotation interval
 				var rotateTimer = function(){
+					clearTimeout(obj.play);
 					obj.play = setTimeout(function(){
 						//trigger slide rotate function at end of timer
 						rotate();


### PR DESCRIPTION
If user click repeatedly on pager nav, transition go out of sync.
clerTimeout in rotateTimer function, reset the timeout each time and risolve this bug.
WORKSFORME
